### PR TITLE
feat: 参加者登録画面の実装 (Issue #1)

### DIFF
--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: React.ReactNode;
+};
+
+export const Button = ({ children, ...props }: ButtonProps) => (
+  <button
+    {...props}
+    className={
+      'px-4 py-2 rounded-md font-medium transition-colors ' +
+      (props.disabled
+        ? 'bg-gray-300 text-gray-400 cursor-not-allowed '
+        : 'bg-blue-600 text-white hover:bg-blue-700 ') +
+      (props.className || '')
+    }
+  >
+    {children}
+  </button>
+); 

--- a/src/components/atoms/IconButton.tsx
+++ b/src/components/atoms/IconButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: React.ReactNode;
+};
+
+export const IconButton = ({ children, ...props }: IconButtonProps) => (
+  <button
+    {...props}
+    className={
+      'p-2 rounded-full transition-colors ' +
+      (props.disabled ? 'bg-gray-200 text-gray-400 cursor-not-allowed ' : 'hover:bg-gray-100 ') +
+      (props.className || '')
+    }
+    type={props.type || 'button'}
+  >
+    {children}
+  </button>
+); 

--- a/src/components/atoms/TextInput.tsx
+++ b/src/components/atoms/TextInput.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const TextInput = (props: TextInputProps) => (
+  <input
+    {...props}
+    className={
+      'bg-white rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 p-2 ' +
+      (props.className || '')
+    }
+  />
+); 

--- a/src/components/molecules/PersonNameEditor.tsx
+++ b/src/components/molecules/PersonNameEditor.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faTimes, faPen, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
+import { TextInput } from '../atoms/TextInput';
+import { IconButton } from '../atoms/IconButton';
+
+interface PersonNameEditorProps {
+  personId: string;
+  name: string;
+  onUpdateName?: (personId: string, newName: string) => void;
+  onDeletePerson: (personId: string) => void;
+}
+
+export const PersonNameEditor = ({ personId, name, onUpdateName, onDeletePerson }: PersonNameEditorProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedName, setEditedName] = useState(name);
+
+  if (isEditing) {
+    return (
+      <div className="flex w-full items-center gap-2">
+        <TextInput
+          type="text"
+          value={editedName.replace(/さん$/, '')}
+          onChange={(e) => setEditedName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              const newName = editedName.endsWith('さん') ? editedName : `${editedName}さん`;
+              if (onUpdateName) { onUpdateName(personId, newName); }
+              setIsEditing(false);
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              setIsEditing(false);
+              setEditedName(name);
+            }
+          }}
+          className="flex-1 text-lg font-medium text-gray-900"
+          autoFocus
+        />
+        <IconButton
+          onClick={() => {
+            const newName = editedName.endsWith('さん') ? editedName : `${editedName}さん`;
+            if (onUpdateName) { onUpdateName(personId, newName); }
+            setIsEditing(false);
+          }}
+          className="text-blue-600 hover:text-blue-700"
+          title="保存"
+        >
+          <FontAwesomeIcon icon={faCheck} />
+        </IconButton>
+        <IconButton
+          onClick={() => {
+            setIsEditing(false);
+            setEditedName(name);
+          }}
+          className="text-gray-600 hover:text-gray-700"
+          title="キャンセル"
+        >
+          <FontAwesomeIcon icon={faTimes} />
+        </IconButton>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <h3 className="flex-1 text-lg font-bold text-gray-900">{name}</h3>
+      <IconButton
+        onClick={() => setIsEditing(true)}
+        className="text-gray-400 hover:text-gray-500"
+        title="編集"
+      >
+        <FontAwesomeIcon icon={faPen} />
+      </IconButton>
+      <IconButton
+        onClick={() => {
+          if (window.confirm('この参加者を削除してもよろしいですか？')) {
+            onDeletePerson(personId);
+          }
+        }}
+        className="ml-auto text-gray-400 hover:text-red-500 transition-colors"
+        title="人物を削除"
+      >
+        <FontAwesomeIcon icon={faTrashAlt} />
+      </IconButton>
+    </div>
+  );
+}; 

--- a/src/components/organisms/ParticipantInput.tsx
+++ b/src/components/organisms/ParticipantInput.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Button } from '../atoms/Button';
+import { TextInput } from '../atoms/TextInput';
+import { PersonNameEditor } from '../molecules/PersonNameEditor';
+
+interface Participant {
+  id: string;
+  name: string;
+}
+
+export const ParticipantInput = ({ onComplete }: { onComplete?: (participants: Participant[]) => void }) => {
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [inputName, setInputName] = useState('');
+
+  const handleAdd = () => {
+    if (!inputName.trim()) return;
+    setParticipants([
+      ...participants,
+      { id: crypto.randomUUID(), name: inputName.trim() },
+    ]);
+    setInputName('');
+  };
+
+  const handleDelete = (id: string) => {
+    setParticipants(participants.filter(p => p.id !== id));
+  };
+
+  const handleUpdateName = (id: string, newName: string) => {
+    setParticipants(participants.map(p => p.id === id ? { ...p, name: newName } : p));
+  };
+
+  return (
+    <>
+      <div className="max-w-md mx-auto bg-white/80 rounded-lg shadow-md p-6 mt-8">
+        <div className="text-center mb-4">
+          <div className="text-lg font-semibold text-gray-800">参加者を登録してください</div>
+          <div className="text-sm text-gray-500 mt-1">（ニックネームや本名どちらでもOK）</div>
+        </div>
+        <form
+          className="flex gap-2 mb-4"
+          onSubmit={e => {
+            e.preventDefault();
+            handleAdd();
+          }}
+        >
+          <TextInput
+            type="text"
+            className="flex-1"
+            placeholder="名前を入力"
+            value={inputName}
+            onChange={e => setInputName(e.target.value)}
+          />
+          <Button type="submit">
+            追加
+          </Button>
+        </form>
+        <ul className="space-y-2">
+          {participants.map(p => (
+            <li key={p.id} className="bg-white rounded p-2 shadow-sm">
+              <PersonNameEditor
+                personId={p.id}
+                name={p.name}
+                onUpdateName={handleUpdateName}
+                onDeletePerson={handleDelete}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+      {onComplete && (
+        <Button
+          className="mt-6 w-full bg-red-500 hover:bg-red-700 font-bold text-lg"
+          onClick={() => onComplete(participants)}
+          disabled={participants.length === 0}
+        >
+          次へ
+        </Button>
+      )}
+    </>
+  );
+}; 

--- a/src/store/peopleSlice.ts
+++ b/src/store/peopleSlice.ts
@@ -1,0 +1,134 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { Person, PaymentItem, PeopleState } from '../types';
+
+const initialState: PeopleState = {
+  people: [
+    {
+      id: crypto.randomUUID(),
+      name: 'Aさん',
+      payments: [{
+        id: crypto.randomUUID(),
+        amount: 0,
+        description: '',
+      }],
+    } as Person,
+    {
+      id: crypto.randomUUID(),
+      name: 'Bさん',
+      payments: [{
+        id: crypto.randomUUID(),
+        amount: 0,
+        description: '',
+      }],
+    } as Person,
+  ],
+  isDetailMode: false,
+  nonPayingParticipants: 0,
+};
+
+export const peopleSlice = createSlice({
+  name: 'people',
+  initialState,
+  reducers: {
+    addPerson: (state) => {
+      // 文字生成ロジックを改善（A, B, C... Z, AA, AB... のように拡張）
+      let nextName = '';
+      const currentCount = state.people.length;
+      
+      if (currentCount < 26) {
+        // A-Z（26文字）
+        nextName = String.fromCharCode(65 + currentCount) + 'さん';
+      } else {
+        // 27文字目以降は AA, AB, AC... のように2文字で表現
+        const firstChar = String.fromCharCode(65 + Math.floor((currentCount - 26) / 26));
+        const secondChar = String.fromCharCode(65 + ((currentCount - 26) % 26));
+        nextName = firstChar + secondChar + 'さん';
+      }
+      
+      state.people.push({
+        id: crypto.randomUUID(),
+        name: nextName,
+        payments: [{
+          id: crypto.randomUUID(),
+          amount: 0,
+          description: '',
+        }],
+      });
+    },
+    updatePersonName: (state, action: PayloadAction<{ personId: string; newName: string }>) => {
+      const person = state.people.find(p => p.id === action.payload.personId);
+      if (person) {
+        person.name = action.payload.newName;
+      }
+    },
+    deletePerson: (state, action: PayloadAction<string>) => {
+      state.people = state.people.filter(p => p.id !== action.payload);
+    },
+    addPayment: (state, action: PayloadAction<{ personId: string; payment: Omit<PaymentItem, 'id'> }>) => {
+      const person = state.people.find(p => p.id === action.payload.personId);
+      if (person) {
+        person.payments.push({
+          id: crypto.randomUUID(),
+          ...action.payload.payment,
+        });
+      }
+    },
+    updatePayment: (state, action: PayloadAction<{ personId: string; paymentId: string; payment: Omit<PaymentItem, 'id'> }>) => {
+      const person = state.people.find(p => p.id === action.payload.personId);
+      if (person) {
+        const payment = person.payments.find(p => p.id === action.payload.paymentId);
+        if (payment) {
+          Object.assign(payment, action.payload.payment);
+        }
+      }
+    },
+    deletePayment: (state, action: PayloadAction<{ personId: string; paymentId: string }>) => {
+      const person = state.people.find(p => p.id === action.payload.personId);
+      if (person) {
+        person.payments = person.payments.filter(p => p.id !== action.payload.paymentId);
+      }
+    },
+    setDetailMode: (state, action: PayloadAction<boolean>) => {
+      state.isDetailMode = action.payload;
+    },
+    setNonPayingParticipants: (state, action: PayloadAction<number>) => {
+      state.nonPayingParticipants = action.payload;
+    },
+    updateSimplePayment: (state, action: PayloadAction<{ personId: string; amount: number }>) => {
+      const person = state.people.find(p => p.id === action.payload.personId);
+      if (person) {
+        // 既存の支払いをクリア
+        person.payments = [];
+        // 新しい支払いを追加
+        person.payments.push({
+          id: crypto.randomUUID(),
+          amount: action.payload.amount,
+          description: '',
+        });
+      }
+    },
+  },
+});
+
+// ストアの初期化時に実行される関数
+export const initializeStore = (state: PeopleState | undefined) => {
+  if (!state) {
+    return initialState;
+  }
+  return state;
+};
+
+export const {
+  addPerson,
+  updatePersonName,
+  deletePerson,
+  addPayment,
+  updatePayment,
+  deletePayment,
+  setDetailMode,
+  setNonPayingParticipants,
+  updateSimplePayment,
+} = peopleSlice.actions;
+
+export default peopleSlice.reducer; 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,34 @@
+import { configureStore } from '@reduxjs/toolkit';
+import peopleReducer, { initializeStore } from './peopleSlice';
+import type { Middleware, AnyAction } from '@reduxjs/toolkit';
+
+// デバッグ用ミドルウェア
+const debugMiddleware: Middleware = (store) => (next) => (action: unknown) => {
+  if (typeof action === 'object' && action !== null && 'type' in action) {
+    console.group(`%c${(action as AnyAction).type}`, 'color: #2196F3; font-weight: bold');
+    console.log('%cPrevious State:', 'color: #9E9E9E; font-weight: bold', store.getState());
+    console.log('%cAction:', 'color: #4CAF50; font-weight: bold', action);
+    
+    const result = next(action);
+    
+    console.log('%cNext State:', 'color: #FF9800; font-weight: bold', store.getState());
+    console.groupEnd();
+    
+    return result;
+  }
+  return next(action);
+};
+
+export const store = configureStore({
+  reducer: {
+    people: peopleReducer,
+  },
+  preloadedState: {
+    people: initializeStore(undefined),
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(debugMiddleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch; 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,30 @@
+export interface Payment {
+  id: string;
+  description: string;
+  amount: number;
+  paidBy: string;
+  participants: string[];
+}
+
+export interface Participant {
+  id: string;
+  name: string;
+}
+
+export interface PaymentItem {
+  id: string;
+  description: string;
+  amount: number;
+}
+
+export interface Person {
+  id: string;
+  name: string;
+  payments: PaymentItem[];
+}
+
+export interface PeopleState {
+  people: Person[];
+  isDetailMode: boolean;
+  nonPayingParticipants: number;
+} 


### PR DESCRIPTION
## 概要

参加者を追加・編集・削除できる画面を実装しました。

## 実装内容

### 機能
- ✅ 参加者の追加（名前入力フィールド + 追加ボタン）
- ✅ 参加者の編集（編集ボタンで名前変更）
- ✅ 参加者の削除（削除ボタン + 確認ダイアログ）
- ✅ 次へボタン（参加者が1人以上いる場合のみ有効）

### コンポーネント構成
- **ParticipantInput** (organisms) - 参加者登録画面全体
- **PersonNameEditor** (molecules) - 個別の参加者編集
- **Button, TextInput, IconButton** (atoms) - 基本UIコンポーネント

### 技術仕様
- Atomic Designの粒度に従ったコンポーネント分割
- TypeScriptによる型安全性の確保
- Redux Toolkitによる状態管理
- FontAwesomeアイコンの活用

## 動作確認
- [ ] 参加者の追加が正常に動作する
- [ ] 参加者の編集が正常に動作する
- [ ] 参加者の削除が正常に動作する
- [ ] 次へボタンが適切に有効/無効になる

Closes #1