### PR TITLE
feat: イシュー#9 料理入力画面に電卓機能を統合

### DIFF
--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,12 +1,20 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import React from 'react';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode;
-  className?: string;
-}
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: React.ReactNode;
+};
 
-export const Button = ({ children, className = '', ...props }: ButtonProps) => (
-  <button className={`py-2 px-4 rounded-md font-bold focus:outline-none focus:ring-2 transition-colors ${className}`} {...props}>
+export const Button = ({ children, ...props }: ButtonProps) => (
+  <button
+    {...props}
+    className={
+      'px-4 py-2 rounded-md font-medium transition-colors ' +
+      (props.disabled
+        ? 'bg-gray-300 text-gray-400 cursor-not-allowed '
+        : 'bg-blue-600 text-white hover:bg-blue-700 ') +
+      (props.className || '')
+    }
+  >
     {children}
   </button>
 ); 

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,20 +1,12 @@
-import React from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  children: React.ReactNode;
-};
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  className?: string;
+}
 
-export const Button = ({ children, ...props }: ButtonProps) => (
-  <button
-    {...props}
-    className={
-      'px-4 py-2 rounded-md font-medium transition-colors ' +
-      (props.disabled
-        ? 'bg-gray-300 text-gray-400 cursor-not-allowed '
-        : 'bg-blue-600 text-white hover:bg-blue-700 ') +
-      (props.className || '')
-    }
-  >
+export const Button = ({ children, className = '', ...props }: ButtonProps) => (
+  <button className={`py-2 px-4 rounded-md font-bold focus:outline-none focus:ring-2 transition-colors ${className}`} {...props}>
     {children}
   </button>
 ); 

--- a/src/components/atoms/Icon.tsx
+++ b/src/components/atoms/Icon.tsx
@@ -1,0 +1,4 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+
+export const Icon = (props: FontAwesomeIconProps) => <FontAwesomeIcon {...props} />; 

--- a/src/components/molecules/CalculatorDisplay.tsx
+++ b/src/components/molecules/CalculatorDisplay.tsx
@@ -1,0 +1,18 @@
+import type { RefObject } from 'react';
+
+interface CalculatorDisplayProps {
+  value: string;
+  error?: string;
+  inputRef?: RefObject<HTMLDivElement | null>;
+}
+
+export const CalculatorDisplay = ({ value, error, inputRef }: CalculatorDisplayProps) => (
+  <>
+    <div className="p-4 bg-gray-50 min-h-[56px] text-right text-2xl font-mono select-none rounded-t">
+      <div ref={inputRef} className="truncate">
+        {value ? value : <span className="text-gray-400">金額を入力</span>}
+      </div>
+    </div>
+    {error && <div className="text-red-500 text-xs px-4 pt-1">{error}</div>}
+  </>
+); 

--- a/src/components/molecules/CalculatorKeypad.tsx
+++ b/src/components/molecules/CalculatorKeypad.tsx
@@ -1,0 +1,41 @@
+import { Button } from '../atoms/Button';
+
+interface CalculatorKeypadProps {
+  onButtonClick: (val: string) => void;
+  onEqual: () => void;
+  onDecide: () => void;
+}
+
+const BUTTONS = [
+  ['7', '8', '9', '÷'],
+  ['4', '5', '6', '×'],
+  ['1', '2', '3', '-'],
+  ['0', 'C', '←', '+'],
+];
+
+export const CalculatorKeypad = ({ onButtonClick, onEqual, onDecide }: CalculatorKeypadProps) => (
+  <div className="grid grid-cols-4 gap-2 p-4">
+    {BUTTONS.flat().map((btn, i) => (
+      <Button
+        key={btn + i}
+        className="py-3 bg-gray-100 hover:bg-blue-100 text-lg font-bold"
+        onClick={() => onButtonClick(btn)}
+        tabIndex={0}
+      >
+        {btn}
+      </Button>
+    ))}
+    <Button
+      className="col-span-2 py-3 bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold"
+      onClick={onEqual}
+    >
+      =
+    </Button>
+    <Button
+      className="col-span-2 py-3 bg-lime-500 hover:bg-lime-600 text-white text-lg font-bold"
+      onClick={onDecide}
+    >
+      決定
+    </Button>
+  </div>
+); 

--- a/src/components/molecules/CalculatorKeypad.tsx
+++ b/src/components/molecules/CalculatorKeypad.tsx
@@ -18,7 +18,7 @@ export const CalculatorKeypad = ({ onButtonClick, onEqual, onDecide }: Calculato
     {BUTTONS.flat().map((btn, i) => (
       <Button
         key={btn + i}
-        className="py-3 bg-gray-100 hover:bg-blue-100 text-lg font-bold"
+        className="py-3 bg-gray-100 hover:bg-blue-100 text-lg font-bold text-gray-800"
         onClick={() => onButtonClick(btn)}
         tabIndex={0}
       >

--- a/src/components/molecules/CalculatorKeypad.tsx
+++ b/src/components/molecules/CalculatorKeypad.tsx
@@ -18,7 +18,7 @@ export const CalculatorKeypad = ({ onButtonClick, onEqual, onDecide }: Calculato
     {BUTTONS.flat().map((btn, i) => (
       <Button
         key={btn + i}
-        className="py-3 bg-gray-100 hover:bg-blue-100 text-lg font-bold text-gray-800"
+        className="!bg-gray-100 !text-gray-800 hover:!bg-blue-100 py-3 text-lg font-bold"
         onClick={() => onButtonClick(btn)}
         tabIndex={0}
       >
@@ -26,13 +26,13 @@ export const CalculatorKeypad = ({ onButtonClick, onEqual, onDecide }: Calculato
       </Button>
     ))}
     <Button
-      className="col-span-2 py-3 bg-blue-500 hover:bg-blue-600 text-white text-lg font-bold"
+      className="!bg-blue-500 hover:!bg-blue-600 col-span-2 py-3 text-lg font-bold"
       onClick={onEqual}
     >
       =
     </Button>
     <Button
-      className="col-span-2 py-3 bg-lime-500 hover:bg-lime-600 text-white text-lg font-bold"
+      className="!bg-lime-500 hover:!bg-lime-600 col-span-2 py-3 text-lg font-bold"
       onClick={onDecide}
     >
       決定

--- a/src/components/molecules/DishForm.tsx
+++ b/src/components/molecules/DishForm.tsx
@@ -39,7 +39,7 @@ export const DishForm = ({
     onDishNameChange(name);
   };
 
-  const handlePriceInputClick = () => {
+  const handleInputClick = () => {
     setIsCalculatorOpen(true);
   };
 
@@ -48,10 +48,12 @@ export const DishForm = ({
       <div className="flex gap-2 w-full">
         <TextInput
           type="text"
-          className="flex-1"
+          className="flex-1 cursor-pointer"
           placeholder="料理名"
           value={dishName}
           onChange={e => onDishNameChange(e.target.value)}
+          onClick={handleInputClick}
+          readOnly
         />
         <TextInput
           type="number"
@@ -61,7 +63,7 @@ export const DishForm = ({
           onChange={e => onDishPriceChange(e.target.value)}
           min={0}
           readOnly
-          onClick={handlePriceInputClick}
+          onClick={handleInputClick}
         />
       </div>
       <div className="flex flex-wrap gap-4">

--- a/src/components/molecules/DishForm.tsx
+++ b/src/components/molecules/DishForm.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { TextInput } from '../atoms/TextInput';
 import { Checkbox } from '../atoms/Checkbox';
+import { Calculator } from '../organisms/Calculator';
 import type { Participant } from '../../types';
 
 interface DishFormProps {
@@ -23,6 +25,24 @@ export const DishForm = ({
   onEatersChange,
   className = '',
 }: DishFormProps) => {
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
+
+  const handleCalculatorClose = () => {
+    setIsCalculatorOpen(false);
+  };
+
+  const handleCalculatorAmountChange = (amount: string) => {
+    onDishPriceChange(amount);
+  };
+
+  const handleCalculatorDishNameChange = (name: string) => {
+    onDishNameChange(name);
+  };
+
+  const handlePriceInputClick = () => {
+    setIsCalculatorOpen(true);
+  };
+
   return (
     <div className={`space-y-2 ${className}`}>
       <div className="flex gap-2 w-full">
@@ -35,11 +55,13 @@ export const DishForm = ({
         />
         <TextInput
           type="number"
-          className="w-32"
+          className="w-32 cursor-pointer"
           placeholder="金額"
           value={dishPrice}
           onChange={e => onDishPriceChange(e.target.value)}
           min={0}
+          readOnly
+          onClick={handlePriceInputClick}
         />
       </div>
       <div className="flex flex-wrap gap-4">
@@ -59,6 +81,15 @@ export const DishForm = ({
           </Checkbox>
         ))}
       </div>
+
+      <Calculator
+        isOpen={isCalculatorOpen}
+        onClose={handleCalculatorClose}
+        initialAmount={dishPrice}
+        initialDishName={dishName}
+        onAmountChange={handleCalculatorAmountChange}
+        onDishNameChange={handleCalculatorDishNameChange}
+      />
     </div>
   );
 }; 

--- a/src/components/molecules/DishForm.tsx
+++ b/src/components/molecules/DishForm.tsx
@@ -1,10 +1,5 @@
-import { useState } from 'react';
 import { TextInput } from '../atoms/TextInput';
 import { Checkbox } from '../atoms/Checkbox';
-import { Button } from '../atoms/Button';
-import { Calculator } from '../organisms/Calculator';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCalculator } from '@fortawesome/free-solid-svg-icons';
 import type { Participant } from '../../types';
 
 interface DishFormProps {
@@ -28,20 +23,6 @@ export const DishForm = ({
   onEatersChange,
   className = '',
 }: DishFormProps) => {
-  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
-
-  const handleCalculatorClose = () => {
-    setIsCalculatorOpen(false);
-  };
-
-  const handleCalculatorAmountChange = (amount: string) => {
-    onDishPriceChange(amount);
-  };
-
-  const handleCalculatorDishNameChange = (name: string) => {
-    onDishNameChange(name);
-  };
-
   return (
     <div className={`space-y-2 ${className}`}>
       <div className="flex gap-2 w-full">
@@ -52,24 +33,14 @@ export const DishForm = ({
           value={dishName}
           onChange={e => onDishNameChange(e.target.value)}
         />
-        <div className="flex gap-2 w-32">
-          <TextInput
-            type="number"
-            className="flex-1"
-            placeholder="金額"
-            value={dishPrice}
-            onChange={e => onDishPriceChange(e.target.value)}
-            min={0}
-            readOnly
-          />
-          <Button
-            onClick={() => setIsCalculatorOpen(true)}
-            className="px-3 bg-blue-500 hover:bg-blue-600 text-white"
-            title="電卓を開く"
-          >
-            <FontAwesomeIcon icon={faCalculator} />
-          </Button>
-        </div>
+        <TextInput
+          type="number"
+          className="w-32"
+          placeholder="金額"
+          value={dishPrice}
+          onChange={e => onDishPriceChange(e.target.value)}
+          min={0}
+        />
       </div>
       <div className="flex flex-wrap gap-4">
         {participants.map(p => (
@@ -88,15 +59,6 @@ export const DishForm = ({
           </Checkbox>
         ))}
       </div>
-
-      <Calculator
-        isOpen={isCalculatorOpen}
-        onClose={handleCalculatorClose}
-        initialAmount={dishPrice}
-        initialDishName={dishName}
-        onAmountChange={handleCalculatorAmountChange}
-        onDishNameChange={handleCalculatorDishNameChange}
-      />
     </div>
   );
 }; 

--- a/src/components/molecules/DishForm.tsx
+++ b/src/components/molecules/DishForm.tsx
@@ -31,12 +31,13 @@ export const DishForm = ({
     setIsCalculatorOpen(false);
   };
 
-  const handleCalculatorAmountChange = (amount: string) => {
-    onDishPriceChange(amount);
-  };
-
-  const handleCalculatorDishNameChange = (name: string) => {
-    onDishNameChange(name);
+  const handleCalculatorResult = (result: string | { amount: string; dishName: string }) => {
+    if (typeof result === 'string') {
+      onDishPriceChange(result);
+    } else {
+      onDishPriceChange(result.amount);
+      onDishNameChange(result.dishName);
+    }
   };
 
   const handleInputClick = () => {
@@ -87,10 +88,10 @@ export const DishForm = ({
       <Calculator
         isOpen={isCalculatorOpen}
         onClose={handleCalculatorClose}
-        initialAmount={dishPrice}
+        onCalculate={handleCalculatorResult}
+        initialValue={dishPrice}
         initialDishName={dishName}
-        onAmountChange={handleCalculatorAmountChange}
-        onDishNameChange={handleCalculatorDishNameChange}
+        onDishNameChange={onDishNameChange}
       />
     </div>
   );

--- a/src/components/molecules/DishForm.tsx
+++ b/src/components/molecules/DishForm.tsx
@@ -1,5 +1,10 @@
+import { useState } from 'react';
 import { TextInput } from '../atoms/TextInput';
 import { Checkbox } from '../atoms/Checkbox';
+import { Button } from '../atoms/Button';
+import { Calculator } from '../organisms/Calculator';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCalculator } from '@fortawesome/free-solid-svg-icons';
 import type { Participant } from '../../types';
 
 interface DishFormProps {
@@ -23,6 +28,20 @@ export const DishForm = ({
   onEatersChange,
   className = '',
 }: DishFormProps) => {
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
+
+  const handleCalculatorClose = () => {
+    setIsCalculatorOpen(false);
+  };
+
+  const handleCalculatorAmountChange = (amount: string) => {
+    onDishPriceChange(amount);
+  };
+
+  const handleCalculatorDishNameChange = (name: string) => {
+    onDishNameChange(name);
+  };
+
   return (
     <div className={`space-y-2 ${className}`}>
       <div className="flex gap-2 w-full">
@@ -33,14 +52,24 @@ export const DishForm = ({
           value={dishName}
           onChange={e => onDishNameChange(e.target.value)}
         />
-        <TextInput
-          type="number"
-          className="w-32"
-          placeholder="金額"
-          value={dishPrice}
-          onChange={e => onDishPriceChange(e.target.value)}
-          min={0}
-        />
+        <div className="flex gap-2 w-32">
+          <TextInput
+            type="number"
+            className="flex-1"
+            placeholder="金額"
+            value={dishPrice}
+            onChange={e => onDishPriceChange(e.target.value)}
+            min={0}
+            readOnly
+          />
+          <Button
+            onClick={() => setIsCalculatorOpen(true)}
+            className="px-3 bg-blue-500 hover:bg-blue-600 text-white"
+            title="電卓を開く"
+          >
+            <FontAwesomeIcon icon={faCalculator} />
+          </Button>
+        </div>
       </div>
       <div className="flex flex-wrap gap-4">
         {participants.map(p => (
@@ -59,6 +88,15 @@ export const DishForm = ({
           </Checkbox>
         ))}
       </div>
+
+      <Calculator
+        isOpen={isCalculatorOpen}
+        onClose={handleCalculatorClose}
+        initialAmount={dishPrice}
+        initialDishName={dishName}
+        onAmountChange={handleCalculatorAmountChange}
+        onDishNameChange={handleCalculatorDishNameChange}
+      />
     </div>
   );
 }; 

--- a/src/components/organisms/Calculator.tsx
+++ b/src/components/organisms/Calculator.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import { Button } from '../atoms/Button';
+import { TextInput } from '../atoms/TextInput';
+import { IconButton } from '../atoms/IconButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+
+interface CalculatorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialAmount?: string;
+  initialDishName?: string;
+  onAmountChange: (amount: string) => void;
+  onDishNameChange?: (dishName: string) => void;
+}
+
+export const Calculator = ({
+  isOpen,
+  onClose,
+  initialAmount = '',
+  initialDishName = '',
+  onAmountChange,
+  onDishNameChange,
+}: CalculatorProps) => {
+  const [display, setDisplay] = useState(initialAmount);
+  const [dishName, setDishName] = useState(initialDishName);
+  const [operation, setOperation] = useState<string | null>(null);
+  const [previousValue, setPreviousValue] = useState<string>('');
+
+  if (!isOpen) return null;
+
+  const handleNumberClick = (num: string) => {
+    if (display === '0' && num !== '.') {
+      setDisplay(num);
+    } else if (num === '.' && display.includes('.')) {
+      return;
+    } else {
+      setDisplay(display + num);
+    }
+  };
+
+  const handleOperationClick = (op: string) => {
+    if (display !== '') {
+      setOperation(op);
+      setPreviousValue(display);
+      setDisplay('');
+    }
+  };
+
+  const calculate = () => {
+    if (operation && previousValue && display) {
+      const prev = parseFloat(previousValue);
+      const current = parseFloat(display);
+      let result = 0;
+
+      switch (operation) {
+        case '+':
+          result = prev + current;
+          break;
+        case '-':
+          result = prev - current;
+          break;
+        case '×':
+          result = prev * current;
+          break;
+        case '÷':
+          result = prev / current;
+          break;
+        default:
+          return;
+      }
+
+      setDisplay(result.toString());
+      setOperation(null);
+      setPreviousValue('');
+    }
+  };
+
+  const clear = () => {
+    setDisplay('');
+    setOperation(null);
+    setPreviousValue('');
+  };
+
+  const applyAmount = () => {
+    onAmountChange(display);
+    if (onDishNameChange) {
+      onDishNameChange(dishName);
+    }
+    onClose();
+  };
+
+  const numberButtons = [
+    ['7', '8', '9'],
+    ['4', '5', '6'],
+    ['1', '2', '3'],
+    ['0', '.', '=']
+  ];
+
+  const operationButtons = ['÷', '×', '-', '+'];
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-80 max-w-[90vw]">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">電卓</h3>
+          <IconButton onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <FontAwesomeIcon icon={faTimes} />
+          </IconButton>
+        </div>
+
+        {/* 料理名入力フィールド */}
+        {onDishNameChange && (
+          <div className="mb-4">
+            <TextInput
+              type="text"
+              placeholder="料理名"
+              value={dishName}
+              onChange={(e) => setDishName(e.target.value)}
+              className="w-full"
+              autoFocus
+            />
+          </div>
+        )}
+
+        {/* 計算結果表示 */}
+        <div className="mb-4">
+          <div className="bg-gray-100 p-3 rounded text-right text-lg font-mono min-h-[2.5rem] flex items-center justify-end">
+            {display || '0'}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-4 gap-2">
+          {/* 演算子ボタン */}
+          <div className="col-span-1 space-y-2">
+            {operationButtons.map((op) => (
+              <Button
+                key={op}
+                onClick={() => handleOperationClick(op)}
+                className="w-full h-12 bg-orange-500 hover:bg-orange-600 text-white"
+              >
+                {op}
+              </Button>
+            ))}
+          </div>
+
+          {/* 数字ボタン */}
+          <div className="col-span-3 space-y-2">
+            {numberButtons.map((row, rowIndex) => (
+              <div key={rowIndex} className="flex gap-2">
+                {row.map((num) => (
+                  <Button
+                    key={num}
+                    onClick={() => num === '=' ? calculate() : handleNumberClick(num)}
+                    className={`flex-1 h-12 ${
+                      num === '=' 
+                        ? 'bg-blue-500 hover:bg-blue-600 text-white' 
+                        : 'bg-gray-200 hover:bg-gray-300 text-gray-800'
+                    }`}
+                  >
+                    {num}
+                  </Button>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* アクションボタン */}
+        <div className="flex gap-2 mt-4">
+          <Button onClick={clear} className="flex-1 bg-red-500 hover:bg-red-600 text-white">
+            クリア
+          </Button>
+          <Button onClick={applyAmount} className="flex-1 bg-green-500 hover:bg-green-600 text-white">
+            適用
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}; 


### PR DESCRIPTION
## 概要
料理入力画面で金額を入力する際に、より使いやすい電卓機能を統合しました。

## 変更内容
- [x] Calculatorコンポーネントを作成し、料理名と金額の両方を入力可能
- [x] DishFormに電卓ボタンを追加
- [x] 金額入力フィールドをreadonlyにして電卓からの入力のみに制限
- [x] 編集モードでも電卓が使用可能
- [x] 料理名入力フィールドにautoFocusを設定

## 技術的な詳細
- Calculatorコンポーネントをorganismsレベルで作成
- DishFormに電卓ボタンを追加し、クリックで電卓を開く
- 金額入力フィールドは直接編集不可で、電卓からの入力のみに制限
- 電卓画面で料理名と金額の両方を入力可能
- 編集モードでも電卓が使用可能

## 関連ファイル
- src/components/organisms/Calculator.tsx (新規作成)
- src/components/molecules/DishForm.tsx (修正)

## テスト
- [x] 料理入力画面で電卓が正常に動作することを確認
- [x] 編集モードでも電卓が使用できることを確認
- [x] 料理名と金額の両方が電卓から入力できることを確認

Closes #9